### PR TITLE
fix: show heap not system memory

### DIFF
--- a/src/Statcord.js
+++ b/src/Statcord.js
@@ -108,12 +108,10 @@ class Statcord extends EventEmitter {
 
         // Get mem stats
         if (this.postMemStatistics) {
-            const mem = await si.mem();
-
-            // Get active memory in MB
-            memactive = mem.active;
-            // Get active mem load in %
-            memload = Math.round(mem.active / mem.total * 100);
+            // Get heap memory in MB
+            memactive = process.memoryUsage().heapUsed;
+            // Get heap mem load in %
+            memload = Math.round(process.memoryUsage().heapUsed / process.memoryUsage().heapTotal * 100);
         }
 
         // Get cpu stats


### PR DESCRIPTION
Since a lot of people tend to run their bots on shared hosting or even multiple bots per server it makes more sense to grab the heap than it does the OS memory size.